### PR TITLE
Add timeout value to Hubspot API requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5,6 +5,9 @@ var request = require('request');
 
 var defaultBaseUrl = 'https://api.hubapi.com';
 
+// default timeout when waiting for a response from the Hubspot API
+const API_TIMEOUT = 15000; // milliseconds
+
 function Client(opts) {
   var self = this;
 
@@ -15,6 +18,7 @@ function Client(opts) {
   self.clientId;
   self.clientSecret;
   self.baseUrl = defaultBaseUrl;
+  self.timeout = opts.timeout || API_TIMEOUT;
 
   function setAccessToken(accessToken) {
     if (!accessToken) {
@@ -54,6 +58,14 @@ function Client(opts) {
     }
 
     self.apiKey = apiKey;
+  }
+
+  function setTimeout(timeout) {
+    if (!timeout) {
+      throw new Error('You must provide a timeout value in milliseconds.');
+    }
+
+    self.timeout = timeout
   }
 
   function refreshAccessToken(cb) {
@@ -469,6 +481,7 @@ function Client(opts) {
   function sendRequest (call, opts, cb) {
     call.json = true;
     call.qs = call.qs || {};
+    call.timeout = opts.timeout || self.timeout;
 
     if (opts.auth) {
       if (self.apiKey) {
@@ -512,7 +525,8 @@ function Client(opts) {
     setClientId: setClientId,
     setClientSecret: setClientSecret,
     refreshAccessToken: refreshAccessToken,
-    setBaseUrl: setBaseUrl
+    setBaseUrl: setBaseUrl,
+    setTimeout: setTimeout,
   }
 }
 


### PR DESCRIPTION
## Description 
https://segment.atlassian.net/browse/SRC-2180
Hubspot API calls occasionally take a long time to respond. The library did not implement any timeout and therefore would wait indefinitely for the server's response. The hubspot source relies on this library and after 30 minutes of no activity, it will be killed by [source runner](https://github.com/segmentio/source-runner/blob/master/source.go#L419). This adds a client-side timeout to allow the request to fail so we can retry. The default timeout is 15 seconds unless specified otherwise by the client. 

## Test Plan 
Tested using a feature branch against this test source: https://app.segment.com/segment-engineering/sources/hubspot24/overview. Set the timeout to be really small (1ms) and observed that the request to Hubspot timed out and retried. From the logs: 
```
[ object-sources/c538037275cd414ea25370e9b780ef3a ] 02-27 01:10:21 INFO args=[map[limit:900 startTimestamp:1.582781827e+12]]  callId=8edb4fb9-8e5c-461e-a427-368029626650  methodName=campaigns.eventsAsPromised  - calling api method
[ object-sources/c538037275cd414ea25370e9b780ef3a ] 02-27 01:10:21 INFO - calling with timeout = 1
[ object-sources/c538037275cd414ea25370e9b780ef3a ] 02-27 01:10:21 ERROR callId=8edb4fb9-8e5c-461e-a427-368029626650  request.args=[map[limit:900 startTimestamp:1.582781827e+12]]  request.fn=campaigns.events  Errors=[ Type=OperationalError Error=ETIMEDOUT  Stack=[at Timeout._onTimeout (/src/node_modules/request/request.js:762:15) at tryOnTimeout (timers.js:228:11) at Timer.listOnTimeout (timers.js:202:5)]]  - api request failed
[ object-sources/c538037275cd414ea25370e9b780ef3a ] 02-27 01:10:21 WARN - retrying request
```

## Deployment Plan
Merge this PR to master. Since this is a library, the changes won't be deployed until the [client is updated to use this version](https://github.com/segmentio/object-sources/blob/master/javascript/hubspot/package.json#L29). 

## Rollback plan
Revert the PR

